### PR TITLE
Combining fixes

### DIFF
--- a/splunkchart/templates/namespace.yaml
+++ b/splunkchart/templates/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: splunk

--- a/splunkchart/templates/secrets.yaml
+++ b/splunkchart/templates/secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: splunk-admin
+type: Opaque
+data:
+  password: {{ b64enc .Values.splunk_password }}

--- a/splunkchart/templates/splunk-indexer-statefulset.yaml
+++ b/splunkchart/templates/splunk-indexer-statefulset.yaml
@@ -69,7 +69,10 @@ spec:
             - name: SPLUNK_SEARCH_HEAD_URL
               value: search
             - name: SPLUNK_PASSWORD
-              value: helloworld
+              valueFrom:
+                secretKeyRef:
+                  name: splunk-admin
+                  key: password
             - name: DEBUG
               value: "true"
           ports:

--- a/splunkchart/templates/splunk-master-deploy.yaml
+++ b/splunkchart/templates/splunk-master-deploy.yaml
@@ -37,7 +37,10 @@ spec:
             - name: SPLUNK_ROLE
               value: splunk_cluster_master
             - name: SPLUNK_PASSWORD
-              value: helloworld
+              valueFrom:
+                secretKeyRef:
+                  name: splunk-admin
+                  key: password
             - name: SPLUNK_START_ARGS
               value: "--accept-license"
             - name: SPLUNK_CLUSTER_MASTER_URL

--- a/splunkchart/templates/splunk-search-deploy.yaml
+++ b/splunkchart/templates/splunk-search-deploy.yaml
@@ -36,7 +36,10 @@ spec:
             - name: SPLUNK_ROLE
               value: splunk_search_head
             - name: SPLUNK_PASSWORD
-              value: helloworld
+              valueFrom:
+                secretKeyRef:
+                  name: splunk-admin
+                  key: password
             - name: SPLUNK_START_ARGS
               value: "--accept-license"
             - name: SPLUNK_CLUSTER_MASTER_URL

--- a/splunkchart/values.yaml
+++ b/splunkchart/values.yaml
@@ -1,8 +1,8 @@
 indexer:
-#  replicaCount: 3
+  replicaCount: null # Defaults to 3 if not specified (null)
 
 master:
-#  replicaCount: 1
+  replicaCount: null # Defaults to 1 if not specified (null)
 
 search:
-#  replicaCount: 1
+  replicaCount: null # Defaults to 1 if not specified (null)

--- a/splunkdefaults/templates/namespace.yaml
+++ b/splunkdefaults/templates/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: splunk


### PR DESCRIPTION
Use a Kubernetes secret for the Splunk admin password rather than hard coding in the templates!

Also, problem with defining the namespace in the Helm chart. The chart release will fail is the namespace already exists, but cleaning up the failed release will delete the existing namespace, and everything in it.